### PR TITLE
Fallback on missing translations

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -50,7 +50,7 @@ export function useLittera<T extends ITranslations<T>>(t: TTranslationsArg<T, IT
   const locales = context.locales ?? [locale];
   
   const translations = React.useMemo(() => isTransFn<T, ITranslationsPreset<typeof preset>>(t) ? { ...t(preset) } : { ...t }, [t, preset]) as T;
-
+  
   React.useEffect(() => {
     reportMissing(translations, locales)
   }, [translations]);

--- a/src/utils/translate.ts
+++ b/src/utils/translate.ts
@@ -98,5 +98,7 @@ export function translateSingle<T>(translation: T, locale: string) {
   if (isVariableFunction(translation))
     return ((...args: Parameters<typeof translation>) => translation(...args)[locale]) as ISingleTranslated<T>;
 
-  return translation[locale] as ISingleTranslated<T>;
+  const defaultLocale = Object.keys(translation)[0];
+
+  return (translation[locale] || translation[defaultLocale]) as ISingleTranslated<T>;
 }

--- a/tests/hooks.spec.tsx
+++ b/tests/hooks.spec.tsx
@@ -163,6 +163,16 @@ describe("useLittera", () => {
     // @ts-ignore
     expect(console.warn.mock.calls[0][0]).toBe(`You are missing "simple" in de_DE.`);
   });
+
+  it("should fall back to available locale if translations for active are missing", () => {
+    console.warn = jest.fn();
+    const render = renderHook(() => useLittera(mockMissingTranslations, "de_DE"), { wrapper });
+    const translated = render.result.current;
+
+    const fallbackLocale = Object.keys(mockMissingTranslations.simple)[0];
+
+    expect(translated.simple).toEqual(mockMissingTranslations.simple[fallbackLocale]);
+  });
 });
 
 describe("useLitteraMethods", () => {


### PR DESCRIPTION
Littera will now fall back to the first available locale when translations for the active locale are not available. The missing translations will still be logged in the console as before.
This PR will solve #14.